### PR TITLE
Improve layout of console ouput

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,5 +230,4 @@ For more information see the [.NET Foundation Code of Conduct](https://dotnetfou
 
 ### .NET Foundation
 
-
 This project is supported by the [.NET Foundation](https://dotnetfoundation.org).

--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ Output:
 
 ```text
 Console export: CompareObjectTypesBenchmark benchmark class.
+
+| -------------------------------------------------------------------- |
 | MethodName                 | ItterationCount | Mean  | Min   | Max   |
 | -------------------------------------------------------------------- |
 | CompareByString            | 10              | 10 ms | 10 ms | 10 ms |
 | CompareUsingTypeofIf       | 10              | 3 ms  | 0 ms  | 10 ms |
 | CompareUsingTypeofIfReturn | 10              | 5 ms  | 0 ms  | 10 ms |
+| -------------------------------------------------------------------- |
 ```
 
 ## How to run .NET **nanoFramework** Benchmark
@@ -156,11 +159,14 @@ Note, that benchmark method must be public and without parameters.
 BaselineAttribute is used to specify which method should be considered as baseline for calculation. Add new column "Ratio" to output.
 ```text
 Console export: CompareObjectTypesBenchmark benchmark class.
+
+| ------------------------------------------------------------------------------ |
 | MethodName                 | ItterationCount | Mean   | Ratio  | Min   | Max   |
 | ------------------------------------------------------------------------------ |
 | CompareByString            | 100             | 10 ms  | 1.0    | 10 ms | 10 ms |
 | CompareUsingTypeofIf       | 100             | 5.9 ms | 0.5900 | 0 ms  | 10 ms |
 | CompareUsingTypeofIfReturn | 100             | 5.5 ms | 0.5500 | 0 ms  | 10 ms |
+| ------------------------------------------------------------------------------ |
 ```
 
 ### Parsers
@@ -179,11 +185,14 @@ Output example
 
 ```text
 Console export: CompareObjectTypesBenchmark benchmark class.
+
+| -------------------------------------------------------------------- |
 | MethodName                 | ItterationCount | Mean   | Min  | Max   |
 | -------------------------------------------------------------------- |
 | CompareByString            | 100             | 8.9 ms | 0 ms | 10 ms |
 | CompareUsingTypeofIf       | 100             | 4.1 ms | 0 ms | 10 ms |
 | CompareUsingTypeofIfReturn | 100             | 4.2 ms | 0 ms | 10 ms |
+| -------------------------------------------------------------------- |
 ```
 
 #### CsvParser
@@ -220,5 +229,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 For more information see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
 ### .NET Foundation
+
 
 This project is supported by the [.NET Foundation](https://dotnetfoundation.org).

--- a/nanoFramework.Benchmark/Parser/Abstract/BaseTextParser.cs
+++ b/nanoFramework.Benchmark/Parser/Abstract/BaseTextParser.cs
@@ -53,6 +53,8 @@ namespace nanoFramework.Benchmark.Parser.Abstract
 
         protected abstract string GetRow(SingleBenchmarkResult item, MethodInfo[] dataToDisplay, int rowIndex);
 
+        protected abstract string GetRowSeparator();
+
         protected virtual void PrintLine(string value)
         {
             Console.WriteLine(value);
@@ -69,14 +71,20 @@ namespace nanoFramework.Benchmark.Parser.Abstract
             PrintLine(string.Empty);
             PrintLine(string.Empty);
             PrintLine(GetParserName(benchmarkResult));
+            PrintLine(string.Empty);
 
             var dataToDisplay = benchmarkResult.GetDataToDisplay();
+
+            PrintLine(GetRowSeparator());
+
             PrintLine(GetHeader(dataToDisplay));
 
             for (int i = 0; i < benchmarkResult.MethodResults.Length; i++)
             {
                 PrintLine(GetRow(benchmarkResult, dataToDisplay, i));
             }
+
+            PrintLine(GetRowSeparator());
         }
     }
 }

--- a/nanoFramework.Benchmark/Parser/ConsoleParser.cs
+++ b/nanoFramework.Benchmark/Parser/ConsoleParser.cs
@@ -15,12 +15,15 @@ namespace nanoFramework.Benchmark.Parser
         private const string ConsoleTableSeparator = "|";
         private readonly object lockObject = new ();
         private int[] columnsSize;
+        private string _tableSeparator;
 
         public override void Parse(SingleBenchmarkResult benchmarkResult)
         {
             lock (lockObject)
             {
                 columnsSize = CalculateColumnSize(benchmarkResult);
+                _tableSeparator = null;
+
                 base.Parse(benchmarkResult);
             }
         }
@@ -63,7 +66,10 @@ namespace nanoFramework.Benchmark.Parser
         protected override string GetHeader(MethodInfo[] dataToDisplay)
         {
             var stringBuilder = new StringBuilder();
+
+            // append column headers
             stringBuilder.Append($"{ConsoleTableSeparator}");
+
             for (int i = 0; i < dataToDisplay.Length; i++)
             {
                 var item = dataToDisplay[i];
@@ -73,18 +79,10 @@ namespace nanoFramework.Benchmark.Parser
                 stringBuilder.Append($" {ConsoleTableSeparator}");
             }
 
-            // Create row after header, seperating rows and headers
-            var headerLength = stringBuilder.Length;
             stringBuilder.AppendLine();
-            stringBuilder.Append($"{ConsoleTableSeparator} ");
 
-            // -4 characters = '| ' + ' |'
-            for (int i = 0; i < headerLength - 4; i++)
-            {
-                stringBuilder.Append("-");
-            }
-
-            stringBuilder.Append($" {ConsoleTableSeparator}");
+            // append table separator to end the header
+            stringBuilder.Append(GetRowSeparator());
 
             return stringBuilder.ToString();
         }
@@ -103,6 +101,35 @@ namespace nanoFramework.Benchmark.Parser
             }
 
             return stringBuilder.ToString();
+        }
+
+        protected override string GetRowSeparator()
+        {
+            if (_tableSeparator == null)
+            {
+                StringBuilder stringBuilder = new ();
+
+                // compute total header length from all columns
+                int headerLength = 0;
+                for (int i = 0; i < columnsSize.Length; i++)
+                {
+                    // account for the space between columns and the separator
+                    headerLength += columnsSize[i] + 3;
+                }
+
+                stringBuilder.Append($"{ConsoleTableSeparator} ");
+
+                // account for the separator and the space at the end (twice)
+                for (int i = 0; i < headerLength - 3; i++)
+                {
+                    stringBuilder.Append("-");
+                }
+
+                stringBuilder.Append($" {ConsoleTableSeparator}");
+                _tableSeparator = stringBuilder.ToString();
+            }
+
+            return _tableSeparator;
         }
     }
 }

--- a/nanoFramework.Benchmark/Parser/CsvParser.cs
+++ b/nanoFramework.Benchmark/Parser/CsvParser.cs
@@ -54,5 +54,10 @@ namespace nanoFramework.Benchmark.Parser
 
             return stringBuilder.ToString();
         }
+
+        protected override string GetRowSeparator()
+        {
+            return string.Empty;
+        }
     }
 }


### PR DESCRIPTION
## Description
- Add new method to get a row separator.
- Refactor GetHeader to use this new method.
- Refactor Parse to add row separator at table start and end.
- Update README with new format.

## Motivation and Context
- When using this on another project felt the need to know when the table ended, which also prompted me to add this to the table beginning for a consistent look.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running the sample app.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
